### PR TITLE
Adjust floating window offset

### DIFF
--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -579,6 +579,8 @@ public abstract partial class FactoryBase
 
         dock.GetPointerScreenPosition(out var dockPointerScreenX, out var dockPointerScreenY);
         dockable.GetPointerScreenPosition(out var dockablePointerScreenX, out var dockablePointerScreenY);
+        dockable.GetPointerPosition(out var pointerX, out var pointerY);
+        dockable.GetTabBounds(out var tabX, out var tabY, out _, out _);
 
         if (double.IsNaN(dockablePointerScreenX))
         {
@@ -604,9 +606,17 @@ public abstract partial class FactoryBase
         {
             dockableWidth = double.IsNaN(ownerWidth) ? 300 : ownerWidth;
         }
+
         if (double.IsNaN(dockableHeight))
         {
             dockableHeight = double.IsNaN(ownerHeight) ? 400 : ownerHeight;
+        }
+
+        if (!double.IsNaN(pointerX) && !double.IsNaN(pointerY) &&
+            !double.IsNaN(tabX) && !double.IsNaN(tabY))
+        {
+            dockablePointerScreenX -= pointerX + tabX;
+            dockablePointerScreenY -= pointerY + tabY;
         }
 
         SplitToWindow(dock, dockable, dockablePointerScreenX, dockablePointerScreenY, dockableWidth, dockableHeight);


### PR DESCRIPTION
## Summary
- compute pointer and tab offset before floating
- offset floating window position so clicked tab stays under the pointer

## Testing
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_687a39ab6f1c833091dc8675875232ba