### PR TITLE
Support window drag via last tab

### DIFF
--- a/src/Dock.Avalonia/Controls/DockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml.cs
@@ -272,9 +272,37 @@ public class DockControl : TemplatedControl, IDockControl
         return DragAction.Move;
     }
 
+    private bool ShouldIgnorePressedForWindowDrag(PointerPressedEventArgs e)
+    {
+        if (e.Source is not Control source)
+        {
+            return false;
+        }
+
+        var tabItem = source.FindAncestorOfType<DocumentTabStripItem>();
+        if (tabItem is null)
+        {
+            return false;
+        }
+
+        var tabStrip = tabItem.FindAncestorOfType<DocumentTabStrip>();
+        if (tabStrip is null)
+        {
+            return false;
+        }
+
+        return tabStrip.Items is { Count: 1 }
+               && tabStrip.DataContext is Dock.Model.Core.IDock { CanCloseLastDockable: false };
+    }
+
     private void PressedHandler(object? sender, PointerPressedEventArgs e)
     {
         if (e.Source is Visual visual && visual.FindAncestorOfType<ScrollBar>() != null)
+        {
+            return;
+        }
+
+        if (ShouldIgnorePressedForWindowDrag(e))
         {
             return;
         }


### PR DESCRIPTION
## Summary
- allow dragging the window via the last tab when closing last dockable is disabled
- avoid starting dock drag when dragging window via last tab

## Testing
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687a50c83d8c8330ac426cc9204e4509