### PR TITLE
WIP: Allow per-root global docking

### DIFF
--- a/docs/dock-settings.md
+++ b/docs/dock-settings.md
@@ -40,9 +40,10 @@ Increase these values if small pointer movements should not initiate dragging.
 
 ## Global docking
 
-`DockSettings.EnableGlobalDocking` controls whether dockables can be dropped
+`IRootDock.EnableGlobalDocking` controls whether dockables can be dropped
 onto other `DockControl` instances. If set to `false` the global dock target is
-hidden and drags are limited to the originating control.
+hidden and drags are limited to the originating control. This option is set per
+root dock, allowing different docks to enable or disable global docking independently.
 
 ## Floating window owner
 
@@ -78,7 +79,6 @@ AppBuilder.Configure<App>()
     .UsePlatformDetect()
     .UseFloatingDockAdorner()
     .UseOwnerForFloatingWindows()
-    .EnableGlobalDocking(false)
     .EnableWindowMagnetism()
     .SetWindowMagnetDistance(16)
     .BringWindowsToFrontOnDrag()

--- a/samples/WebViewSample/Program.cs
+++ b/samples/WebViewSample/Program.cs
@@ -14,7 +14,7 @@ internal class Program
         WebView.Settings.OsrEnabled = false;
 
         DockSettings.UseFloatingDockAdorner = true;
-        DockSettings.EnableGlobalDocking = true;
+        // Global docking is now configured per root dock via IRootDock.EnableGlobalDocking
 
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
     }

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -4,8 +4,8 @@ using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.VisualTree;
-using Dock.Avalonia.Controls;
 using Dock.Avalonia.Contract;
+using Dock.Avalonia.Controls;
 using Dock.Model.Controls;
 using Dock.Model.Core;
 using Dock.Settings;
@@ -20,7 +20,7 @@ internal class DockDragContext
     public bool DoDragDrop { get; set; }
     public Point TargetPoint { get; set; }
     public Visual? TargetDockControl { get; set; }
-    
+
     public PixelPoint DragOffset { get; set; }
 
     public void Start(Control dragControl, Point point)
@@ -162,7 +162,7 @@ internal class DockControlState : DockManagerState, IDockControlState
                 && dockControlLayout.ActiveDockable is IDock dockControlActiveDock)
             {
                 var targetDock = DockHelpers.FindProportionalDock(dockControlActiveDock) ?? dockControlActiveDock;
-    
+
                 // TODO: The validation fails in floating window as ActiveDockable is a tool dock.
                 // if (!ValidateGlobalTarget(sourceDockable, targetDock))
                 // {
@@ -212,12 +212,13 @@ internal class DockControlState : DockManagerState, IDockControlState
 
     private bool ValidateGlobal(Point point, DockOperation operation, DragAction dragAction, Visual relativeTo)
     {
-        if (!DockSettings.EnableGlobalDocking)
+        if (_context.DragControl?.DataContext is not IDockable sourceDockable)
         {
             return false;
         }
 
-        if (_context.DragControl?.DataContext is not IDockable sourceDockable)
+        var sourceDockControl = _context.DragControl.FindAncestorOfType<DockControl>();
+        if (sourceDockControl?.Layout is not IRootDock sourceRoot || !sourceRoot.EnableGlobalDocking)
         {
             return false;
         }
@@ -228,7 +229,7 @@ internal class DockControlState : DockManagerState, IDockControlState
         }
 
         var dockControl = dropCtrl.FindAncestorOfType<DockControl>();
-        if (dockControl?.Layout is not { ActiveDockable: IDock activeDock })
+        if (dockControl?.Layout is not IRootDock { ActiveDockable: IDock activeDock } targetRoot || !targetRoot.EnableGlobalDocking)
         {
             return false;
         }
@@ -253,7 +254,7 @@ internal class DockControlState : DockManagerState, IDockControlState
         {
             return false;
         }
-        
+
         return DockManager.ValidateDockable(sourceDockable, targetDock, dragAction, operation, bExecute: false);
     }
 
@@ -311,136 +312,171 @@ internal class DockControlState : DockManagerState, IDockControlState
         switch (eventType)
         {
             case EventType.Pressed:
-            {
-                var dragControl = DockHelpers.GetControl(inputActiveDockControl, point, DockProperties.IsDragAreaProperty);
-                if (dragControl is { })
                 {
-                    var isDragEnabled = dragControl.GetValue(DockProperties.IsDragEnabledProperty);
-                    if (!isDragEnabled)
+                    var dragControl = DockHelpers.GetControl(inputActiveDockControl, point, DockProperties.IsDragAreaProperty);
+                    if (dragControl is { })
                     {
-                        break;
-                    }
-                    
-                    if (dragControl.DataContext is IDockable { CanDrag: false })
-                    {
-                        break;
-                    }
-
-                    _context.Start(dragControl, point);
-                    DropControl = null;
-                    activeDockControl.IsDraggingDock = true;
-                }
-                break;
-            }
-            case EventType.Released:
-            {
-                if (_context.DoDragDrop)
-                {
-                    var executed = false;
-
-                    if (DropControl is { } dropControl && _context.TargetDockControl is { })
-                    {
-                        var isDropEnabled = dropControl.GetValue(DockProperties.IsDropEnabledProperty);
-                        if (isDropEnabled)
+                        var isDragEnabled = dragControl.GetValue(DockProperties.IsDragEnabledProperty);
+                        if (!isDragEnabled)
                         {
-                            Drop(_context.TargetPoint, dragAction, dropControl, _context.TargetDockControl);
-                            executed = true;
-                        }
-                    }
-
-                    if (!executed && _context.DragControl?.DataContext is IDockable dockable &&
-                        inputActiveDockControl.Layout?.Factory is { } factory)
-                    {
-                        Float(point, inputActiveDockControl, dockable, factory);
-                    }
-                }
-
-                _dragPreviewHelper.Hide();
-
-                Leave();
-                _context.End();
-                DropControl = null;
-                activeDockControl.IsDraggingDock = false;
-                break;
-            }
-            case EventType.Moved:
-            {
-                if (_context.PointerPressed == false)
-                {
-                    break;
-                }
-
-                if (_context.DoDragDrop == false)
-                {
-                    Vector diff = _context.DragStartPoint - point;
-                    var haveMinimumDragDistance = DockSettings.IsMinimumDragDistance(diff);
-                    if (haveMinimumDragDistance)
-                    {
-                        if (_context.DragControl?.DataContext is IDockable targetDockable)
-                        {
-                            DockHelpers.ShowWindows(targetDockable);
-                            var sp = inputActiveDockControl.PointToScreen(point);
-
-                            _context.DragOffset = DragOffsetCalculator.CalculateOffset(
-                                _context.DragControl, inputActiveDockControl, _context.DragStartPoint);
-
-                            _dragPreviewHelper.Show(targetDockable, sp, _context.DragOffset);
-                        }
-                        _context.DoDragDrop = true;
-                    }
-                }
-
-                if (_context.DoDragDrop)
-                {
-                    Point targetPoint = default;
-                    Visual? targetDockControl = null;
-                    Control? dropControl = null;
-
-                    var screenPoint = inputActiveDockControl.PointToScreen(point);
-                    var preview = "None";
-
-                    foreach (var inputDockControl in DockHelpers.GetZOrderedDockControls(dockControls))
-                    {
-                        if (inputActiveDockControl.GetVisualRoot() is null)
-                        {
-                            continue;
-                        }
-
-                        if (inputDockControl.GetVisualRoot() is null)
-                        {
-                            continue;
-                        }
-                        var dockControlPoint = inputDockControl.PointToClient(screenPoint);
-
-                        dropControl = DockHelpers.GetControl(inputDockControl, dockControlPoint, DockProperties.IsDropAreaProperty);
-                        if (dropControl is { })
-                        {
-                            targetPoint = dockControlPoint;
-                            targetDockControl = inputDockControl;
                             break;
                         }
-                    }
 
-                    if (dropControl is null)
-                    {
-                        dropControl = DockHelpers.GetControl(inputActiveDockControl, point, DockProperties.IsDropAreaProperty);
-                        if (dropControl is { })
+                        if (dragControl.DataContext is IDockable { CanDrag: false })
                         {
-                            targetPoint = point;
-                            targetDockControl = inputActiveDockControl;
+                            break;
+                        }
+
+                        _context.Start(dragControl, point);
+                        DropControl = null;
+                        activeDockControl.IsDraggingDock = true;
+                    }
+                    break;
+                }
+            case EventType.Released:
+                {
+                    if (_context.DoDragDrop)
+                    {
+                        var executed = false;
+
+                        if (DropControl is { } dropControl && _context.TargetDockControl is { })
+                        {
+                            var isDropEnabled = dropControl.GetValue(DockProperties.IsDropEnabledProperty);
+                            if (isDropEnabled)
+                            {
+                                Drop(_context.TargetPoint, dragAction, dropControl, _context.TargetDockControl);
+                                executed = true;
+                            }
+                        }
+
+                        if (!executed && _context.DragControl?.DataContext is IDockable dockable &&
+                            inputActiveDockControl.Layout?.Factory is { } factory)
+                        {
+                            Float(point, inputActiveDockControl, dockable, factory);
                         }
                     }
 
-                    if (dropControl is { } && targetDockControl is { })
+                    _dragPreviewHelper.Hide();
+
+                    Leave();
+                    _context.End();
+                    DropControl = null;
+                    activeDockControl.IsDraggingDock = false;
+                    break;
+                }
+            case EventType.Moved:
+                {
+                    if (_context.PointerPressed == false)
                     {
-                        var isDropEnabled = dropControl.GetValue(DockProperties.IsDropEnabledProperty);
-                        if (isDropEnabled)
+                        break;
+                    }
+
+                    if (_context.DoDragDrop == false)
+                    {
+                        Vector diff = _context.DragStartPoint - point;
+                        var haveMinimumDragDistance = DockSettings.IsMinimumDragDistance(diff);
+                        if (haveMinimumDragDistance)
                         {
-                            if (DropControl == dropControl)
+                            if (_context.DragControl?.DataContext is IDockable targetDockable)
                             {
-                                _context.TargetPoint = targetPoint;
-                                _context.TargetDockControl = targetDockControl;
-                                Over(targetPoint, dragAction, dropControl, targetDockControl);
+                                DockHelpers.ShowWindows(targetDockable);
+                                var sp = inputActiveDockControl.PointToScreen(point);
+
+                                _context.DragOffset = DragOffsetCalculator.CalculateOffset(
+                                    _context.DragControl, inputActiveDockControl, _context.DragStartPoint);
+
+                                _dragPreviewHelper.Show(targetDockable, sp, _context.DragOffset);
+                            }
+                            _context.DoDragDrop = true;
+                        }
+                    }
+
+                    if (_context.DoDragDrop)
+                    {
+                        Point targetPoint = default;
+                        Visual? targetDockControl = null;
+                        Control? dropControl = null;
+
+                        var screenPoint = inputActiveDockControl.PointToScreen(point);
+                        var preview = "None";
+
+                        foreach (var inputDockControl in DockHelpers.GetZOrderedDockControls(dockControls))
+                        {
+                            if (inputActiveDockControl.GetVisualRoot() is null)
+                            {
+                                continue;
+                            }
+
+                            if (inputDockControl.GetVisualRoot() is null)
+                            {
+                                continue;
+                            }
+                            var dockControlPoint = inputDockControl.PointToClient(screenPoint);
+
+                            dropControl = DockHelpers.GetControl(inputDockControl, dockControlPoint, DockProperties.IsDropAreaProperty);
+                            if (dropControl is { })
+                            {
+                                targetPoint = dockControlPoint;
+                                targetDockControl = inputDockControl;
+                                break;
+                            }
+                        }
+
+                        if (dropControl is null)
+                        {
+                            dropControl = DockHelpers.GetControl(inputActiveDockControl, point, DockProperties.IsDropAreaProperty);
+                            if (dropControl is { })
+                            {
+                                targetPoint = point;
+                                targetDockControl = inputActiveDockControl;
+                            }
+                        }
+
+                        if (dropControl is { } && targetDockControl is { })
+                        {
+                            var isDropEnabled = dropControl.GetValue(DockProperties.IsDropEnabledProperty);
+                            if (isDropEnabled)
+                            {
+                                if (DropControl == dropControl)
+                                {
+                                    _context.TargetPoint = targetPoint;
+                                    _context.TargetDockControl = targetDockControl;
+                                    Over(targetPoint, dragAction, dropControl, targetDockControl);
+                                }
+                                else
+                                {
+                                    if (DropControl is { })
+                                    {
+                                        Leave();
+                                        DropControl = null;
+                                    }
+
+                                    DropControl = dropControl;
+                                    _context.TargetPoint = targetPoint;
+                                    _context.TargetDockControl = targetDockControl;
+                                    Enter(targetPoint, dragAction, targetDockControl);
+                                }
+
+                                var globalOperation = GlobalAdornerHelper.Adorner is GlobalDockTarget globalDockTarget
+                                    ? globalDockTarget.GetDockOperation(targetPoint, dropControl, targetDockControl, dragAction, ValidateGlobal, IsDockTargetVisible)
+                                    : DockOperation.None;
+
+                                var localOperation = LocalAdornerHelper.Adorner is DockTarget dockTarget
+                                    ? dockTarget.GetDockOperation(targetPoint, dropControl, targetDockControl, dragAction, ValidateLocal, IsDockTargetVisible)
+                                    : DockOperation.Fill;
+
+                                if (globalOperation != DockOperation.None)
+                                {
+                                    var valid = ValidateGlobal(targetPoint, localOperation, dragAction, targetDockControl);
+                                    preview = valid ? "Dock" : "None";
+                                }
+                                else
+                                {
+                                    var valid = ValidateLocal(targetPoint, localOperation, dragAction, targetDockControl);
+                                    preview = valid
+                                        ? localOperation == DockOperation.Window ? "Float" : "Dock"
+                                        : "None";
+                                }
                             }
                             else
                             {
@@ -448,81 +484,46 @@ internal class DockControlState : DockManagerState, IDockControlState
                                 {
                                     Leave();
                                     DropControl = null;
+                                    _context.TargetPoint = default;
+                                    _context.TargetDockControl = null;
                                 }
-
-                                DropControl = dropControl;
-                                _context.TargetPoint = targetPoint;
-                                _context.TargetDockControl = targetDockControl;
-                                Enter(targetPoint, dragAction, targetDockControl);
-                            }
-
-                            var globalOperation = GlobalAdornerHelper.Adorner is GlobalDockTarget globalDockTarget
-                                ? globalDockTarget.GetDockOperation(targetPoint, dropControl, targetDockControl, dragAction, ValidateGlobal, IsDockTargetVisible)
-                                : DockOperation.None;
-
-                            var localOperation = LocalAdornerHelper.Adorner is DockTarget dockTarget
-                                ? dockTarget.GetDockOperation(targetPoint, dropControl, targetDockControl, dragAction, ValidateLocal, IsDockTargetVisible)
-                                : DockOperation.Fill;
-
-                            if (globalOperation != DockOperation.None)
-                            {
-                                var valid = ValidateGlobal(targetPoint, localOperation, dragAction, targetDockControl);
-                                preview = valid ? "Dock" : "None";
-                            }
-                            else
-                            {
-                                var valid = ValidateLocal(targetPoint, localOperation, dragAction, targetDockControl);
-                                preview = valid
-                                    ? localOperation == DockOperation.Window ? "Float" : "Dock"
-                                    : "None";
+                                preview = "Float";
                             }
                         }
                         else
                         {
-                            if (DropControl is { })
-                            {
-                                Leave();
-                                DropControl = null;
-                                _context.TargetPoint = default;
-                                _context.TargetDockControl = null;
-                            }
+                            Leave();
+                            DropControl = null;
+                            _context.TargetPoint = default;
+                            _context.TargetDockControl = null;
                             preview = "Float";
                         }
-                    }
-                    else
-                    {
-                        Leave();
-                        DropControl = null;
-                        _context.TargetPoint = default;
-                        _context.TargetDockControl = null;
-                        preview = "Float";
-                    }
 
-                    _dragPreviewHelper.Move(screenPoint, _context.DragOffset, preview);
+                        _dragPreviewHelper.Move(screenPoint, _context.DragOffset, preview);
+                    }
+                    break;
                 }
-                break;
-            }
             case EventType.Enter:
-            {
-                break;
-            }
+                {
+                    break;
+                }
             case EventType.Leave:
-            {
-                break;
-            }
+                {
+                    break;
+                }
             case EventType.CaptureLost:
-            {
-                _dragPreviewHelper.Hide();
-                Leave();
-                _context.End();
-                DropControl = null;
-                activeDockControl.IsDraggingDock = false;
-                break;
-            }
+                {
+                    _dragPreviewHelper.Hide();
+                    Leave();
+                    _context.End();
+                    DropControl = null;
+                    activeDockControl.IsDraggingDock = false;
+                    break;
+                }
             case EventType.WheelChanged:
-            {
-                break;
-            }
+                {
+                    break;
+                }
         }
     }
 }

--- a/src/Dock.Avalonia/Internal/DockManagerState.cs
+++ b/src/Dock.Avalonia/Internal/DockManagerState.cs
@@ -23,7 +23,7 @@ internal abstract class DockManagerState : IDockManagerState
     protected AdornerHelper<DockTarget> LocalAdornerHelper { get; }
 
     protected AdornerHelper<GlobalDockTarget> GlobalAdornerHelper { get; }
- 
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DockManagerState"/> class.
     /// </summary>
@@ -46,11 +46,11 @@ internal abstract class DockManagerState : IDockManagerState
         }
 
         // Global dock target
-        if (DockSettings.EnableGlobalDocking && isGlobalValid && DropControl is { } dropControl)
+        if (isGlobalValid && DropControl is { } dropControl)
         {
             // Try to find DockControl ancestor - look through the visual tree more thoroughly
             var dockControl = dropControl.FindAncestorOfType<DockControl>();
-            
+
             // If not found directly, walk up the visual tree manually
             if (dockControl is null)
             {
@@ -65,7 +65,7 @@ internal abstract class DockManagerState : IDockManagerState
                     current = current.GetVisualParent();
                 }
             }
-            
+
             if (dockControl is not null)
             {
                 var indicatorsOnly = DockProperties.GetShowDockIndicatorOnly(dropControl);
@@ -84,11 +84,11 @@ internal abstract class DockManagerState : IDockManagerState
         }
 
         // Global dock target
-        if (DockSettings.EnableGlobalDocking && DropControl is { } dropControl)
+        if (DropControl is { } dropControl)
         {
             // Try to find DockControl ancestor - look through the visual tree more thoroughly
             var dockControl = dropControl.FindAncestorOfType<DockControl>();
-            
+
             // If not found directly, walk up the visual tree manually
             if (dockControl is null)
             {
@@ -103,7 +103,7 @@ internal abstract class DockManagerState : IDockManagerState
                     current = current.GetVisualParent();
                 }
             }
-            
+
             if (dockControl is not null)
             {
                 GlobalAdornerHelper.RemoveAdorner(dockControl);

--- a/src/Dock.Model.Avalonia/Controls/RootDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/RootDock.cs
@@ -25,9 +25,19 @@ public class RootDock : DockBase, IRootDock
     /// </summary>
     public static readonly DirectProperty<RootDock, bool> IsFocusableRootProperty =
         AvaloniaProperty.RegisterDirect<RootDock, bool>(
-            nameof(IsFocusableRoot), 
-            o => o.IsFocusableRoot, 
-            (o, v) => o.IsFocusableRoot = v, 
+            nameof(IsFocusableRoot),
+            o => o.IsFocusableRoot,
+            (o, v) => o.IsFocusableRoot = v,
+            true);
+
+    /// <summary>
+    /// Defines the <see cref="EnableGlobalDocking"/> property.
+    /// </summary>
+    public static readonly DirectProperty<RootDock, bool> EnableGlobalDockingProperty =
+        AvaloniaProperty.RegisterDirect<RootDock, bool>(
+            nameof(EnableGlobalDocking),
+            o => o.EnableGlobalDocking,
+            (o, v) => o.EnableGlobalDocking = v,
             true);
 
     /// <summary>
@@ -35,8 +45,8 @@ public class RootDock : DockBase, IRootDock
     /// </summary>
     public static readonly DirectProperty<RootDock, IList<IDockable>?> HiddenDockablesProperty =
         AvaloniaProperty.RegisterDirect<RootDock, IList<IDockable>?>(
-            nameof(HiddenDockables), 
-            o => o.HiddenDockables, 
+            nameof(HiddenDockables),
+            o => o.HiddenDockables,
             (o, v) => o.HiddenDockables = v);
 
     /// <summary>
@@ -44,7 +54,7 @@ public class RootDock : DockBase, IRootDock
     /// </summary>
     public static readonly DirectProperty<RootDock, IList<IDockable>?> LeftPinnedDockablesProperty =
         AvaloniaProperty.RegisterDirect<RootDock, IList<IDockable>?>(
-            nameof(LeftPinnedDockables), o => o.LeftPinnedDockables, 
+            nameof(LeftPinnedDockables), o => o.LeftPinnedDockables,
             (o, v) => o.LeftPinnedDockables = v);
 
     /// <summary>
@@ -60,7 +70,7 @@ public class RootDock : DockBase, IRootDock
     /// </summary>
     public static readonly DirectProperty<RootDock, IList<IDockable>?> RightPinnedDockablesProperty =
         AvaloniaProperty.RegisterDirect<RootDock, IList<IDockable>?>(
-            nameof(RightPinnedDockables), o => o.RightPinnedDockables, 
+            nameof(RightPinnedDockables), o => o.RightPinnedDockables,
             (o, v) => o.RightPinnedDockables = v);
 
     /// <summary>
@@ -68,7 +78,7 @@ public class RootDock : DockBase, IRootDock
     /// </summary>
     public static readonly DirectProperty<RootDock, IList<IDockable>?> TopPinnedDockablesProperty =
         AvaloniaProperty.RegisterDirect<RootDock, IList<IDockable>?>(
-            nameof(TopPinnedDockables), o => o.TopPinnedDockables, 
+            nameof(TopPinnedDockables), o => o.TopPinnedDockables,
             (o, v) => o.TopPinnedDockables = v);
 
     /// <summary>
@@ -76,7 +86,7 @@ public class RootDock : DockBase, IRootDock
     /// </summary>
     public static readonly DirectProperty<RootDock, IList<IDockable>?> BottomPinnedDockablesProperty =
         AvaloniaProperty.RegisterDirect<RootDock, IList<IDockable>?>(
-            nameof(BottomPinnedDockables), o => o.BottomPinnedDockables, 
+            nameof(BottomPinnedDockables), o => o.BottomPinnedDockables,
             (o, v) => o.BottomPinnedDockables = v);
 
     /// <summary>
@@ -84,8 +94,8 @@ public class RootDock : DockBase, IRootDock
     /// </summary>
     public static readonly DirectProperty<RootDock, IDockWindow?> WindowProperty =
         AvaloniaProperty.RegisterDirect<RootDock, IDockWindow?>(
-            nameof(Window), 
-            o => o.Window, 
+            nameof(Window),
+            o => o.Window,
             (o, v) => o.Window = v);
 
     /// <summary>
@@ -93,11 +103,12 @@ public class RootDock : DockBase, IRootDock
     /// </summary>
     public static readonly DirectProperty<RootDock, IList<IDockWindow>?> WindowsProperty =
         AvaloniaProperty.RegisterDirect<RootDock, IList<IDockWindow>?>(
-            nameof(Windows), 
-            o => o.Windows, 
+            nameof(Windows),
+            o => o.Windows,
             (o, v) => o.Windows = v);
 
     private bool _isFocusableRoot;
+    private bool _enableGlobalDocking;
     private IList<IDockable>? _hiddenDockables;
     private IList<IDockable>? _leftPinnedDockables;
     private IList<IDockable>? _rightPinnedDockables;
@@ -113,6 +124,7 @@ public class RootDock : DockBase, IRootDock
     public RootDock()
     {
         _isFocusableRoot = true;
+        _enableGlobalDocking = true;
         _hiddenDockables = new AvaloniaList<IDockable>();
         _leftPinnedDockables = new AvaloniaList<IDockable>();
         _rightPinnedDockables = new AvaloniaList<IDockable>();
@@ -130,6 +142,15 @@ public class RootDock : DockBase, IRootDock
     {
         get => _isFocusableRoot;
         set => SetAndRaise(IsFocusableRootProperty, ref _isFocusableRoot, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("EnableGlobalDocking")]
+    public bool EnableGlobalDocking
+    {
+        get => _enableGlobalDocking;
+        set => SetAndRaise(EnableGlobalDockingProperty, ref _enableGlobalDocking, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Inpc/Controls/RootDock.cs
+++ b/src/Dock.Model.Inpc/Controls/RootDock.cs
@@ -16,6 +16,7 @@ namespace Dock.Model.Inpc.Controls;
 public class RootDock : DockBase, IRootDock
 {
     private bool _isFocusableRoot = true;
+    private bool _enableGlobalDocking = true;
     private IList<IDockable>? _hiddenDockables;
     private IList<IDockable>? _leftPinnedDockables;
     private IList<IDockable>? _rightPinnedDockables;
@@ -40,6 +41,14 @@ public class RootDock : DockBase, IRootDock
     {
         get => _isFocusableRoot;
         set => SetProperty(ref _isFocusableRoot, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public bool EnableGlobalDocking
+    {
+        get => _enableGlobalDocking;
+        set => SetProperty(ref _enableGlobalDocking, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Mvvm/Controls/RootDock.cs
+++ b/src/Dock.Model.Mvvm/Controls/RootDock.cs
@@ -17,6 +17,7 @@ namespace Dock.Model.Mvvm.Controls;
 public class RootDock : DockBase, IRootDock
 {
     private bool _isFocusableRoot = true;
+    private bool _enableGlobalDocking = true;
     private IList<IDockable>? _hiddenDockables;
     private IList<IDockable>? _leftPinnedDockables;
     private IList<IDockable>? _rightPinnedDockables;
@@ -41,6 +42,14 @@ public class RootDock : DockBase, IRootDock
     {
         get => _isFocusableRoot;
         set => SetProperty(ref _isFocusableRoot, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public bool EnableGlobalDocking
+    {
+        get => _enableGlobalDocking;
+        set => SetProperty(ref _enableGlobalDocking, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Prism/Controls/RootDock.cs
+++ b/src/Dock.Model.Prism/Controls/RootDock.cs
@@ -3,10 +3,10 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Windows.Input;
-using Prism.Commands;
 using Dock.Model.Controls;
 using Dock.Model.Core;
 using Dock.Model.Prism.Core;
+using Prism.Commands;
 
 namespace Dock.Model.Prism.Controls;
 
@@ -17,6 +17,7 @@ namespace Dock.Model.Prism.Controls;
 public class RootDock : DockBase, IRootDock
 {
     private bool _isFocusableRoot = true;
+    private bool _enableGlobalDocking = true;
     private IList<IDockable>? _hiddenDockables;
     private IList<IDockable>? _leftPinnedDockables;
     private IList<IDockable>? _rightPinnedDockables;
@@ -41,6 +42,14 @@ public class RootDock : DockBase, IRootDock
     {
         get => _isFocusableRoot;
         set => SetProperty(ref _isFocusableRoot, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public bool EnableGlobalDocking
+    {
+        get => _enableGlobalDocking;
+        set => SetProperty(ref _enableGlobalDocking, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.ReactiveProperty/Controls/RootDock.cs
+++ b/src/Dock.Model.ReactiveProperty/Controls/RootDock.cs
@@ -17,6 +17,7 @@ namespace Dock.Model.ReactiveProperty.Controls;
 public class RootDock : DockBase, IRootDock
 {
     private bool _isFocusableRoot = true;
+    private bool _enableGlobalDocking = true;
     private IList<IDockable>? _hiddenDockables;
     private IList<IDockable>? _leftPinnedDockables;
     private IList<IDockable>? _rightPinnedDockables;
@@ -41,6 +42,14 @@ public class RootDock : DockBase, IRootDock
     {
         get => _isFocusableRoot;
         set => SetProperty(ref _isFocusableRoot, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public bool EnableGlobalDocking
+    {
+        get => _enableGlobalDocking;
+        set => SetProperty(ref _enableGlobalDocking, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.ReactiveUI/Controls/RootDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/RootDock.cs
@@ -22,6 +22,7 @@ public partial class RootDock : DockBase, IRootDock
     public RootDock()
     {
         _isFocusableRoot = true;
+        _enableGlobalDocking = true;
         ShowWindows = ReactiveCommand.Create(() => _navigateAdapter.ShowWindows());
         ExitWindows = ReactiveCommand.Create(() => _navigateAdapter.ExitWindows());
     }
@@ -29,6 +30,10 @@ public partial class RootDock : DockBase, IRootDock
     /// <inheritdoc/>
     [DataMember(IsRequired = false, EmitDefaultValue = true)]
     public partial bool IsFocusableRoot { get; set; }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial bool EnableGlobalDocking { get; set; }
 
     /// <inheritdoc/>
     [DataMember(IsRequired = false, EmitDefaultValue = true)]

--- a/src/Dock.Model/Controls/IRootDock.cs
+++ b/src/Dock.Model/Controls/IRootDock.cs
@@ -18,6 +18,11 @@ public interface IRootDock : IDock
     bool IsFocusableRoot { get; set; }
 
     /// <summary>
+    /// Gets or sets whether this root dock allows docking with other dock controls.
+    /// </summary>
+    bool EnableGlobalDocking { get; set; }
+
+    /// <summary>
     /// Gets or sets hidden dockables.
     /// </summary>
     IList<IDockable>? HiddenDockables { get; set; }

--- a/src/Dock.Model/FactoryBase.cs
+++ b/src/Dock.Model/FactoryBase.cs
@@ -41,25 +41,25 @@ public abstract partial class FactoryBase : IFactory
         {
             if (dock is IToolDock toolDock)
             {
-                if (toolDock.Alignment == Alignment.Left 
+                if (toolDock.Alignment == Alignment.Left
                     && IsDockPinned(rootDock.LeftPinnedDockables, dock))
                 {
                     return;
                 }
 
-                if (toolDock.Alignment == Alignment.Right 
+                if (toolDock.Alignment == Alignment.Right
                     && IsDockPinned(rootDock.RightPinnedDockables, dock))
                 {
                     return;
                 }
 
-                if (toolDock.Alignment == Alignment.Top 
+                if (toolDock.Alignment == Alignment.Top
                     && IsDockPinned(rootDock.TopPinnedDockables, dock))
                 {
                     return;
                 }
 
-                if (toolDock.Alignment == Alignment.Bottom 
+                if (toolDock.Alignment == Alignment.Bottom
                     && IsDockPinned(rootDock.BottomPinnedDockables, dock))
                 {
                     return;
@@ -148,44 +148,44 @@ public abstract partial class FactoryBase : IFactory
         {
             case DockOperation.Left:
             case DockOperation.Right:
-            {
-                layout.Orientation = Orientation.Horizontal;
-                break;
-            }
+                {
+                    layout.Orientation = Orientation.Horizontal;
+                    break;
+                }
             case DockOperation.Top:
             case DockOperation.Bottom:
-            {
-                layout.Orientation = Orientation.Vertical;
-                break;
-            }
+                {
+                    layout.Orientation = Orientation.Vertical;
+                    break;
+                }
         }
 
         switch (operation)
         {
             case DockOperation.Left:
             case DockOperation.Top:
-            {
-                if (layout.VisibleDockables is not null)
                 {
-                    AddVisibleDockable(layout, split);
-                    OnDockableAdded(split);
-                    layout.ActiveDockable = split;
-                }
+                    if (layout.VisibleDockables is not null)
+                    {
+                        AddVisibleDockable(layout, split);
+                        OnDockableAdded(split);
+                        layout.ActiveDockable = split;
+                    }
 
-                break;
-            }
+                    break;
+                }
             case DockOperation.Right:
             case DockOperation.Bottom:
-            {
-                if (layout.VisibleDockables is not null)
                 {
-                    AddVisibleDockable(layout, dock);
-                    OnDockableAdded(dock);
-                    layout.ActiveDockable = dock;
-                }
+                    if (layout.VisibleDockables is not null)
+                    {
+                        AddVisibleDockable(layout, dock);
+                        OnDockableAdded(dock);
+                        layout.ActiveDockable = dock;
+                    }
 
-                break;
-            }
+                    break;
+                }
         }
 
         AddVisibleDockable(layout, splitter);
@@ -195,28 +195,28 @@ public abstract partial class FactoryBase : IFactory
         {
             case DockOperation.Left:
             case DockOperation.Top:
-            {
-                if (layout.VisibleDockables is not null)
                 {
-                    AddVisibleDockable(layout, dock);
-                    OnDockableAdded(dock);
-                    layout.ActiveDockable = dock;
-                }
+                    if (layout.VisibleDockables is not null)
+                    {
+                        AddVisibleDockable(layout, dock);
+                        OnDockableAdded(dock);
+                        layout.ActiveDockable = dock;
+                    }
 
-                break;
-            }
+                    break;
+                }
             case DockOperation.Right:
             case DockOperation.Bottom:
-            {
-                if (layout.VisibleDockables is not null)
                 {
-                    AddVisibleDockable(layout, split);
-                    OnDockableAdded(split);
-                    layout.ActiveDockable = split;
-                }
+                    if (layout.VisibleDockables is not null)
+                    {
+                        AddVisibleDockable(layout, split);
+                        OnDockableAdded(split);
+                        layout.ActiveDockable = split;
+                    }
 
-                break;
-            }
+                    break;
+                }
         }
 
         return layout;
@@ -231,102 +231,102 @@ public abstract partial class FactoryBase : IFactory
             case DockOperation.Right:
             case DockOperation.Top:
             case DockOperation.Bottom:
-            {
-                if (dock.Owner is IDock ownerDock && ownerDock.VisibleDockables is { })
                 {
-                    var index = ownerDock.VisibleDockables.IndexOf(dock);
-                    if (index >= 0)
+                    if (dock.Owner is IDock ownerDock && ownerDock.VisibleDockables is { })
                     {
-                        // Check if the owner is already a ProportionalDock with compatible orientation
-                        if (ownerDock is IProportionalDock proportionalOwner)
+                        var index = ownerDock.VisibleDockables.IndexOf(dock);
+                        if (index >= 0)
                         {
-                            var requiredOrientation = operation switch
+                            // Check if the owner is already a ProportionalDock with compatible orientation
+                            if (ownerDock is IProportionalDock proportionalOwner)
                             {
-                                DockOperation.Left or DockOperation.Right => Orientation.Horizontal,
-                                DockOperation.Top or DockOperation.Bottom => Orientation.Vertical,
-                                _ => throw new NotSupportedException($"Not supported split operation: {operation}.")
-                            };
-
-                            // If the owner already has the required orientation, add directly to it
-                            if (proportionalOwner.Orientation == requiredOrientation)
-                            {
-                                IDock? split;
-
-                                if (dockable is IDock dockableDock)
+                                var requiredOrientation = operation switch
                                 {
-                                    split = dockableDock;
-                                }
-                                else
+                                    DockOperation.Left or DockOperation.Right => Orientation.Horizontal,
+                                    DockOperation.Top or DockOperation.Bottom => Orientation.Vertical,
+                                    _ => throw new NotSupportedException($"Not supported split operation: {operation}.")
+                                };
+
+                                // If the owner already has the required orientation, add directly to it
+                                if (proportionalOwner.Orientation == requiredOrientation)
                                 {
-                                    split = CreateProportionalDock();
-                                    split.Title = nameof(IProportionalDock);
-                                    split.VisibleDockables = CreateList<IDockable>();
-                                    if (split.VisibleDockables is not null)
+                                    IDock? split;
+
+                                    if (dockable is IDock dockableDock)
                                     {
-                                        AddVisibleDockable(split, dockable);
-                                        OnDockableAdded(dockable);
-                                        split.ActiveDockable = dockable;
+                                        split = dockableDock;
                                     }
+                                    else
+                                    {
+                                        split = CreateProportionalDock();
+                                        split.Title = nameof(IProportionalDock);
+                                        split.VisibleDockables = CreateList<IDockable>();
+                                        if (split.VisibleDockables is not null)
+                                        {
+                                            AddVisibleDockable(split, dockable);
+                                            OnDockableAdded(dockable);
+                                            split.ActiveDockable = dockable;
+                                        }
+                                    }
+
+                                    var splitter = CreateProportionalDockSplitter();
+                                    splitter.Title = nameof(IProportionalDockSplitter);
+
+                                    // Store the original dock's proportion and split it equally
+                                    var originalProportion = dock.Proportion;
+                                    var halfProportion = double.IsNaN(originalProportion) ? double.NaN : originalProportion / 2.0;
+                                    dock.Proportion = halfProportion;
+                                    split.Proportion = halfProportion;
+
+                                    switch (operation)
+                                    {
+                                        case DockOperation.Left:
+                                        case DockOperation.Top:
+                                            {
+                                                // Insert split before dock
+                                                InsertVisibleDockable(proportionalOwner, index, split);
+                                                OnDockableAdded(split);
+                                                InsertVisibleDockable(proportionalOwner, index + 1, splitter);
+                                                OnDockableAdded(splitter);
+                                                InitDockable(split, proportionalOwner);
+                                                break;
+                                            }
+                                        case DockOperation.Right:
+                                        case DockOperation.Bottom:
+                                            {
+                                                // Insert split after dock
+                                                InsertVisibleDockable(proportionalOwner, index + 1, splitter);
+                                                OnDockableAdded(splitter);
+                                                InsertVisibleDockable(proportionalOwner, index + 2, split);
+                                                OnDockableAdded(split);
+                                                InitDockable(split, proportionalOwner);
+                                                break;
+                                            }
+                                    }
+
+                                    // Clean up any orphaned splitters that might have been created
+                                    CleanupOrphanedSplitters(proportionalOwner);
+
+                                    OnDockableUndocked(dockable, operation);
+                                    OnDockableDocked(dockable, operation);
+                                    return;
                                 }
-
-                                var splitter = CreateProportionalDockSplitter();
-                                splitter.Title = nameof(IProportionalDockSplitter);
-
-                                // Store the original dock's proportion and split it equally
-                                var originalProportion = dock.Proportion;
-                                var halfProportion = double.IsNaN(originalProportion) ? double.NaN : originalProportion / 2.0;
-                                dock.Proportion = halfProportion;
-                                split.Proportion = halfProportion;
-
-                                switch (operation)
-                                {
-                                    case DockOperation.Left:
-                                    case DockOperation.Top:
-                                    {
-                                        // Insert split before dock
-                                        InsertVisibleDockable(proportionalOwner, index, split);
-                                        OnDockableAdded(split);
-                                        InsertVisibleDockable(proportionalOwner, index + 1, splitter);
-                                        OnDockableAdded(splitter);
-                                        InitDockable(split, proportionalOwner);
-                                        break;
-                                    }
-                                    case DockOperation.Right:
-                                    case DockOperation.Bottom:
-                                    {
-                                        // Insert split after dock
-                                        InsertVisibleDockable(proportionalOwner, index + 1, splitter);
-                                        OnDockableAdded(splitter);
-                                        InsertVisibleDockable(proportionalOwner, index + 2, split);
-                                        OnDockableAdded(split);
-                                        InitDockable(split, proportionalOwner);
-                                        break;
-                                    }
-                                }
-
-                                // Clean up any orphaned splitters that might have been created
-                                CleanupOrphanedSplitters(proportionalOwner);
-
-                                OnDockableUndocked(dockable, operation);
-                                OnDockableDocked(dockable, operation);
-                                return;
                             }
-                        }
 
-                        // Fallback to the original behavior when optimization is not applicable
-                        var layout = CreateSplitLayout(dock, dockable, operation);
-                        RemoveVisibleDockableAt(ownerDock, index);
-                        OnDockableRemoved(dockable);
-                        OnDockableUndocked(dockable, operation);
-                        InsertVisibleDockable(ownerDock, index, layout);
-                        OnDockableAdded(dockable);
-                        InitDockable(layout, ownerDock);
-                        ownerDock.ActiveDockable = layout;
-                        OnDockableDocked(dockable, operation);
+                            // Fallback to the original behavior when optimization is not applicable
+                            var layout = CreateSplitLayout(dock, dockable, operation);
+                            RemoveVisibleDockableAt(ownerDock, index);
+                            OnDockableRemoved(dockable);
+                            OnDockableUndocked(dockable, operation);
+                            InsertVisibleDockable(ownerDock, index, layout);
+                            OnDockableAdded(dockable);
+                            InitDockable(layout, ownerDock);
+                            ownerDock.ActiveDockable = layout;
+                            OnDockableDocked(dockable, operation);
+                        }
                     }
+                    break;
                 }
-                break;
-            }
             default:
                 throw new NotSupportedException($"Not supported split operation: {operation}.");
         }
@@ -340,86 +340,92 @@ public abstract partial class FactoryBase : IFactory
         switch (dockable)
         {
             case ITool:
-            {
-                target = CreateToolDock();
-                target.Title = nameof(IToolDock);
-                if (target is IDock dock)
                 {
-                    dock.VisibleDockables = CreateList<IDockable>();
-                    if (dock.VisibleDockables is not null)
+                    target = CreateToolDock();
+                    target.Title = nameof(IToolDock);
+                    if (target is IDock dock)
                     {
-                        AddVisibleDockable(dock, dockable);
-                        OnDockableAdded(dockable);
-                        dock.ActiveDockable = dockable;
-                    }
-                }
-                break;
-            }
-            case IDocument:
-            {
-                target = CreateDocumentDock();
-                target.Title = nameof(IDocumentDock);
-                if (target is IDock dock)
-                {
-                    dock.VisibleDockables = CreateList<IDockable>();
-                    if (dockable.Owner is IDocumentDock sourceDocumentDock)
-                    {
-                        if (target is IDocumentDock targetDocumentDock)
+                        dock.VisibleDockables = CreateList<IDockable>();
+                        if (dock.VisibleDockables is not null)
                         {
-                            targetDocumentDock.Id = sourceDocumentDock.Id;
-                            targetDocumentDock.CanCreateDocument = sourceDocumentDock.CanCreateDocument;
-                            targetDocumentDock.EnableWindowDrag = sourceDocumentDock.EnableWindowDrag;
-
-                            if (sourceDocumentDock is IDocumentDockContent sourceDocumentDockContent
-                                && targetDocumentDock is IDocumentDockContent targetDocumentDockContent)
-                            {
-                                
-                                targetDocumentDockContent.DocumentTemplate = sourceDocumentDockContent.DocumentTemplate;
-                            }
+                            AddVisibleDockable(dock, dockable);
+                            OnDockableAdded(dockable);
+                            dock.ActiveDockable = dockable;
                         }
                     }
-                    if (dock.VisibleDockables is not null)
-                    {
-                        AddVisibleDockable(dock, dockable);
-                        OnDockableAdded(dockable);
-                        dock.ActiveDockable = dockable;
-                    }
+                    break;
                 }
-                break;
-            }
+            case IDocument:
+                {
+                    target = CreateDocumentDock();
+                    target.Title = nameof(IDocumentDock);
+                    if (target is IDock dock)
+                    {
+                        dock.VisibleDockables = CreateList<IDockable>();
+                        if (dockable.Owner is IDocumentDock sourceDocumentDock)
+                        {
+                            if (target is IDocumentDock targetDocumentDock)
+                            {
+                                targetDocumentDock.Id = sourceDocumentDock.Id;
+                                targetDocumentDock.CanCreateDocument = sourceDocumentDock.CanCreateDocument;
+                                targetDocumentDock.EnableWindowDrag = sourceDocumentDock.EnableWindowDrag;
+
+                                if (sourceDocumentDock is IDocumentDockContent sourceDocumentDockContent
+                                    && targetDocumentDock is IDocumentDockContent targetDocumentDockContent)
+                                {
+
+                                    targetDocumentDockContent.DocumentTemplate = sourceDocumentDockContent.DocumentTemplate;
+                                }
+                            }
+                        }
+                        if (dock.VisibleDockables is not null)
+                        {
+                            AddVisibleDockable(dock, dockable);
+                            OnDockableAdded(dockable);
+                            dock.ActiveDockable = dockable;
+                        }
+                    }
+                    break;
+                }
             case IToolDock:
-            {
-                target = dockable;
-                break;
-            }
+                {
+                    target = dockable;
+                    break;
+                }
             case IDocumentDock:
-            {
-                target = dockable;
-                break;
-            }
+                {
+                    target = dockable;
+                    break;
+                }
             case IProportionalDock proportionalDock:
-            {
-                target = proportionalDock;
-                break;
-            }
+                {
+                    target = proportionalDock;
+                    break;
+                }
             case IDockDock dockDock:
-            {
-                target = dockDock;
-                break;
-            }
+                {
+                    target = dockDock;
+                    break;
+                }
             case IRootDock rootDock:
-            {
-                target = rootDock.ActiveDockable;
-                break;
-            }
+                {
+                    target = rootDock.ActiveDockable;
+                    break;
+                }
             default:
-            {
-                return null;
-            }
+                {
+                    return null;
+                }
         }
+
+        var sourceRoot = FindRoot(dockable, _ => true);
 
         var root = CreateRootDock();
         root.Title = nameof(IRootDock);
+        if (sourceRoot is not null)
+        {
+            root.EnableGlobalDocking = sourceRoot.EnableGlobalDocking;
+        }
         root.VisibleDockables = CreateList<IDockable>();
         if (root.VisibleDockables is not null && target is not null)
         {

--- a/src/Dock.Settings/AppBuilderExtensions.cs
+++ b/src/Dock.Settings/AppBuilderExtensions.cs
@@ -45,11 +45,6 @@ public static class AppBuilderExtensions
             DockSettings.UsePinnedDockWindow = options.UsePinnedDockWindow.Value;
         }
 
-        if (options.EnableGlobalDocking != null)
-        {
-            DockSettings.EnableGlobalDocking = options.EnableGlobalDocking.Value;
-        }
-
         if (options.UseOwnerForFloatingWindows != null)
         {
             DockSettings.UseOwnerForFloatingWindows = options.UseOwnerForFloatingWindows.Value;
@@ -98,20 +93,6 @@ public static class AppBuilderExtensions
         bool enable = true)
     {
         DockSettings.UsePinnedDockWindow = enable;
-        return builder;
-    }
-
-    /// <summary>
-    /// Sets <see cref="DockSettings.EnableGlobalDocking"/> to the given value.
-    /// </summary>
-    /// <param name="builder">The app builder.</param>
-    /// <param name="enable">Whether to allow docking between controls.</param>
-    /// <returns>The app builder instance.</returns>
-    public static AppBuilder EnableGlobalDocking(
-        this AppBuilder builder,
-        bool enable = true)
-    {
-        DockSettings.EnableGlobalDocking = enable;
         return builder;
     }
 

--- a/src/Dock.Settings/DockSettings.cs
+++ b/src/Dock.Settings/DockSettings.cs
@@ -32,11 +32,6 @@ public static class DockSettings
     public static bool UsePinnedDockWindow = false;
 
     /// <summary>
-    /// Allow docking between different dock control instances.
-    /// </summary>
-    public static bool EnableGlobalDocking = true;
-    
-    /// <summary>
     /// Floating windows use the main window as their owner so they stay in front.
     /// </summary>
     public static bool UseOwnerForFloatingWindows = true;

--- a/src/Dock.Settings/DockSettingsOptions.cs
+++ b/src/Dock.Settings/DockSettingsOptions.cs
@@ -29,11 +29,6 @@ public class DockSettingsOptions
     public bool? UsePinnedDockWindow { get; set; }
 
     /// <summary>
-    /// Optional global docking flag.
-    /// </summary>
-    public bool? EnableGlobalDocking { get; set; }
-
-    /// <summary>
     /// Optional floating window owner flag.
     /// </summary>
     public bool? UseOwnerForFloatingWindows { get; set; }

--- a/tests/Dock.Avalonia.HeadlessTests/GlobalDockingValidationTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/GlobalDockingValidationTests.cs
@@ -4,7 +4,6 @@ using Dock.Model;
 using Dock.Model.Avalonia;
 using Dock.Model.Avalonia.Controls;
 using Dock.Model.Core;
-using Dock.Settings;
 using Xunit;
 
 namespace Dock.Avalonia.HeadlessTests;
@@ -33,7 +32,7 @@ public class GlobalDockingValidationTests
             CanDrop = true,
             Owner = owner
         };
-        
+
         // If no owner specified, create a simple owner dock
         if (owner == null)
         {
@@ -47,7 +46,7 @@ public class GlobalDockingValidationTests
             };
             tool.Owner = ownerDock;
         }
-        
+
         return tool;
     }
 
@@ -147,36 +146,6 @@ public class GlobalDockingValidationTests
         Assert.False(result, "Grouped source should NOT be able to dock into non-grouped global target");
     }
 
-    [AvaloniaFact]
-    public void GlobalDocking_DisabledSetting_ShouldReject()
-    {
-        // NOTE: The global docking setting is enforced at the UI level (ValidateGlobal methods)
-        // rather than in DockManager.ValidateTool. This test demonstrates that the setting
-        // check works in the validation layer where it's implemented.
-        var originalSetting = DockSettings.EnableGlobalDocking;
-        try
-        {
-            DockSettings.EnableGlobalDocking = false;
-            
-            // Test through direct validation call to verify setting is respected
-            var source = CreateTool("Source", "Source Tool", dockGroup: null);
-            var target = CreateGlobalTarget("Target", dockGroup: null);
-
-            // This should pass since we're using the low-level DockManager validation
-            // which doesn't check the global docking setting (that's done at UI level)
-            var dockManager = CreateDockManager();
-            var result = dockManager.ValidateTool(source, target, DragAction.Move, DockOperation.Fill, false);
-            
-            // The actual global docking setting enforcement happens in ValidateGlobal methods
-            // in DockControlState and HostWindowState, which our tests show are working correctly
-            Assert.True(result, "DockManager.ValidateTool doesn't check global docking setting - that's done at UI level");
-        }
-        finally
-        {
-            DockSettings.EnableGlobalDocking = originalSetting;
-        }
-    }
-
     #endregion
 
     #region Comprehensive Rule Testing
@@ -210,26 +179,26 @@ public class GlobalDockingValidationTests
         // Test Rule 1: Non-grouped can dock into non-grouped global target
         var nonGroupedTool = CreateTool("NonGrouped", "Non-grouped Tool", null);
         var nonGroupedGlobalTarget = CreateGlobalTarget("NonGroupedGlobal", null);
-        
+
         var result1 = dockManager.ValidateTool(nonGroupedTool, nonGroupedGlobalTarget, DragAction.Move, DockOperation.Fill, false);
         Assert.True(result1, "Non-grouped tool should be able to dock into non-grouped global target");
 
         // Test Rule 1: Non-grouped CAN dock into grouped global target (can dock anywhere)
         var groupedGlobalTarget = CreateGlobalTarget("GroupedGlobal", "GroupA");
-        
+
         var result2 = dockManager.ValidateTool(nonGroupedTool, groupedGlobalTarget, DragAction.Move, DockOperation.Fill, false);
         Assert.True(result2, "Non-grouped tool should be able to dock globally anywhere");
 
         // Test Rule 2: Grouped CANNOT dock globally (blocked entirely)
         var groupedTool = CreateTool("Grouped", "Grouped Tool", "GroupA");
         var sameGroupGlobalTarget = CreateGlobalTarget("SameGroupGlobal", "GroupA");
-        
+
         var result3 = dockManager.ValidateTool(groupedTool, sameGroupGlobalTarget, DragAction.Move, DockOperation.Fill, false);
         Assert.False(result3, "Grouped tool should NOT be able to dock globally (blocked entirely)");
 
         // Test Rule 2: Grouped sources are blocked from global docking (regardless of target group)
         var differentGroupGlobalTarget = CreateGlobalTarget("DifferentGroupGlobal", "GroupB");
-        
+
         var result4 = dockManager.ValidateTool(groupedTool, differentGroupGlobalTarget, DragAction.Move, DockOperation.Fill, false);
         Assert.False(result4, "Grouped tool should NOT be able to dock globally (blocked entirely)");
     }
@@ -238,7 +207,7 @@ public class GlobalDockingValidationTests
     public void Integration_DockGroupValidator_GlobalValidation()
     {
         // Test the DockGroupValidator.ValidateGlobalDocking directly to ensure our logic is sound
-        
+
         // Rule 1: Non-grouped sources can dock globally anywhere
         var result1 = DockGroupValidator.ValidateGlobalDocking(
             CreateTool("Source", "Tool", null),

--- a/tests/Dock.Settings.UnitTests/AppBuilderExtensionsTests.cs
+++ b/tests/Dock.Settings.UnitTests/AppBuilderExtensionsTests.cs
@@ -21,7 +21,6 @@ public class AppBuilderExtensionsTests
             MinimumVerticalDragDistance = 12,
             UseFloatingDockAdorner = true,
             UsePinnedDockWindow = true,
-            EnableGlobalDocking = false,
             UseOwnerForFloatingWindows = false
         };
 
@@ -32,7 +31,6 @@ public class AppBuilderExtensionsTests
         Assert.Equal(12, DockSettings.MinimumVerticalDragDistance);
         Assert.True(DockSettings.UseFloatingDockAdorner);
         Assert.True(DockSettings.UsePinnedDockWindow);
-        Assert.False(DockSettings.EnableGlobalDocking);
         Assert.False(DockSettings.UseOwnerForFloatingWindows);
     }
 
@@ -63,12 +61,10 @@ public class AppBuilderExtensionsTests
 
         builder.UseFloatingDockAdorner(true)
                .UsePinnedDockWindow(true)
-               .EnableGlobalDocking(false)
                .UseOwnerForFloatingWindows(false);
 
         Assert.True(DockSettings.UseFloatingDockAdorner);
         Assert.True(DockSettings.UsePinnedDockWindow);
-        Assert.False(DockSettings.EnableGlobalDocking);
         Assert.False(DockSettings.UseOwnerForFloatingWindows);
     }
 }


### PR DESCRIPTION
## Summary
- move global docking toggle from static DockSettings to `IRootDock.EnableGlobalDocking`
- respect per-root setting in drag validation and adorner rendering
- copy `EnableGlobalDocking` when new dock windows are created

## Testing
- `dotnet format`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6894465975e483309f1387466ad1c906