### PR TITLE
Select neighbour tab only when closing active tab

### DIFF
--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -51,18 +51,23 @@ public abstract partial class FactoryBase
             return;
         }
 
+        var wasActive = dock.ActiveDockable == dockable;
+
         RemoveVisibleDockable(dock, dockable);
         OnDockableRemoved(dockable);
 
-        var indexActiveDockable = index > 0 ? index - 1 : 0;
-        if (dock.VisibleDockables.Count > 0)
+        if (wasActive)
         {
-            var nextActiveDockable = dock.VisibleDockables[indexActiveDockable];
-            dock.ActiveDockable = nextActiveDockable is not ISplitter ? nextActiveDockable : null;
-        }
-        else
-        {
-            dock.ActiveDockable = null;
+            var indexActiveDockable = index > 0 ? index - 1 : 0;
+            if (dock.VisibleDockables.Count > 0)
+            {
+                var nextActiveDockable = dock.VisibleDockables[indexActiveDockable];
+                dock.ActiveDockable = nextActiveDockable is not ISplitter ? nextActiveDockable : null;
+            }
+            else
+            {
+                dock.ActiveDockable = null;
+            }
         }
 
         // Clean up orphaned splitters

--- a/tests/Dock.Avalonia.HeadlessTests/FactoryDockableLifecycleTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/FactoryDockableLifecycleTests.cs
@@ -64,4 +64,44 @@ public class FactoryDockableLifecycleTests
 
         Assert.Empty(dock.VisibleDockables!);
     }
+
+    [AvaloniaFact]
+    public void CloseDockable_NonActive_Does_Not_Change_ActiveDockable()
+    {
+        var factory = new Factory();
+        var dock = new ProportionalDock { VisibleDockables = factory.CreateList<IDockable>() };
+        dock.Factory = factory;
+
+        var doc1 = new Document();
+        var doc2 = new Document();
+        factory.AddDockable(dock, doc1);
+        factory.AddDockable(dock, doc2);
+
+        dock.ActiveDockable = doc1;
+
+        factory.CloseDockable(doc2);
+
+        Assert.Same(doc1, dock.ActiveDockable);
+        Assert.Single(dock.VisibleDockables!);
+    }
+
+    [AvaloniaFact]
+    public void CloseDockable_Active_Selects_Neighbour()
+    {
+        var factory = new Factory();
+        var dock = new ProportionalDock { VisibleDockables = factory.CreateList<IDockable>() };
+        dock.Factory = factory;
+
+        var doc1 = new Document();
+        var doc2 = new Document();
+        factory.AddDockable(dock, doc1);
+        factory.AddDockable(dock, doc2);
+
+        dock.ActiveDockable = doc1;
+
+        factory.CloseDockable(doc1);
+
+        Assert.Same(doc2, dock.ActiveDockable);
+        Assert.Single(dock.VisibleDockables!);
+    }
 }


### PR DESCRIPTION
## Summary
- avoid resetting active dockable when closing an inactive tab
- add tests for closing active and inactive dockables
- remove unrelated whitespace changes

## Testing
- `dotnet format Dock.sln --no-restore --include src/Dock.Model/FactoryBase.Dockable.cs tests/Dock.Avalonia.HeadlessTests/FactoryDockableLifecycleTests.cs -v diag`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ba01ed5e048330865d4d69ec71dd81