### PR TITLE
Prevent ExitWindows enumeration from crashing on collection changes

### DIFF
--- a/src/Dock.Model/Adapters/NavigateAdapter.cs
+++ b/src/Dock.Model/Adapters/NavigateAdapter.cs
@@ -219,7 +219,8 @@ public class NavigateAdapter : INavigateAdapter
     {
         if (_dock is IRootDock rootDock && rootDock.Windows is { })
         {
-            foreach (var window in rootDock.Windows)
+            var windows = rootDock.Windows.ToList();
+            foreach (var window in windows)
             {
                 window.Save();
                 window.Exit();


### PR DESCRIPTION
## Summary
- snapshot the root dock windows collection before closing each window
- avoid InvalidOperationException caused by Exit removing windows during iteration

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e66fe742688330a7400b52531871fc